### PR TITLE
BBQ - Temperature indicates BBQ in use

### DIFF
--- a/automations/house/bbq/bbq_in_use.yaml
+++ b/automations/house/bbq/bbq_in_use.yaml
@@ -1,0 +1,34 @@
+alias: 'BBQ - Temperature indicates BBQ in use'
+
+trigger:
+
+  - platform: numeric_state
+    entity_id: sensor.esph_bbq_ambient_temperature
+    above: '70'
+
+condition:
+
+  - condition: and
+    conditions:
+
+    - condition: state
+      entity_id: input_boolean.occupied_bbq
+      state: "off"
+
+action:
+
+  - service: notify.html5_notification
+    data_template:
+      title: "🍗 BBQ warming up"
+      message: "The BBQ is at {{ states('sensor.esph_bbq_ambient_temperature') }}°C."
+
+  - service: notify.ios_james_iphone
+    data_template:
+      title: "🍗 BBQ warming up"
+      message: "The BBQ is at {{ states('sensor.esph_bbq_ambient_temperature') }}°C."
+
+  - service: input_boolean.turn_on
+    entity_id: input_boolean.occupied_bbq
+
+  - service: counter.increment
+    entity_id: counter.bbq_usage

--- a/entities/counters/bbq_usage.yaml
+++ b/entities/counters/bbq_usage.yaml
@@ -1,0 +1,4 @@
+bbq_usage:
+  name: BBQ Usage
+  step: 1
+  icon: mdi:grill


### PR DESCRIPTION
Triggers when BBQ rises above a certain temperature.
To avoid multiple notifications the BBQ must no already be in-use.
Send a notification to share the progress of the BBQ temperature.
Change the state of the BBQ to be in-use.
Increment a usage counter.