### PR TITLE
Sonos sleep timer button

### DIFF
--- a/automations/areas/bedroom/sonos_sleep_timer/short_press.yaml
+++ b/automations/areas/bedroom/sonos_sleep_timer/short_press.yaml
@@ -1,0 +1,50 @@
+alias: 'Bedroom - Sonos Sleep Timer'
+id: 'e238b5c5-47e8-439e-881e-47e87367c9a8'
+description: 'Set sleep timer on the bedroom Sonos.'
+initial_state: true
+mode: single
+
+trigger:
+
+  - platform: device
+    domain: zha
+    device_id: c506a4cec1354ca5b9a38eb14b06d147 # Bedroom Aqara button
+    type: remote_button_short_press
+    subtype: remote_button_short_press
+
+condition: []
+
+action:
+
+  # Play selected music source.
+  - service: media_player.select_source
+    data_template:
+      entity_id: media_player.sonos_bedroom
+      source: "{{ states('input_select.bedroom_sonos_source') }}"
+
+  # Pause all other players.
+  # //TODO pause Florence Echo Dot as well?
+  - service: media_player.media_pause
+    data:
+      entity_id:
+        - media_player.sonos_bathroom
+
+  # Set volume.
+  - service: media_player.volume_set
+    data_template:
+      entity_id: media_player.sonos_bedroom
+      volume_level: "{{ states('input_number.bedroom_sleep_timer_volume') | int / 100 }}"
+
+  # Play selected source after the volume has been changed.
+  - service: media_player.media_play
+    data:
+      entity_id: media_player.sonos_bedroom
+
+  # Play for specified duration (take minutes from helper and multiply to get seconds)
+  - service: sonos.set_sleep_timer
+    data_template:
+      entity_id: media_player.sonos_bedroom
+      sleep_time: "{{ states('input_number.bedroom_sleep_timer') | int * 60 }}"
+
+# Related:
+# https://github.com/jcallaghan/home-assistant-config/issues/264

--- a/entities/input_number/bedroom_sleep_timer.yaml
+++ b/entities/input_number/bedroom_sleep_timer.yaml
@@ -1,0 +1,8 @@
+bedroom_sleep_timer:
+  name: Sleep Timer
+  min: 15
+  max: 180
+  step: 15
+  initial: 60
+  unit_of_measurement: 'mins'
+  icon: mdi:timer-outline

--- a/entities/input_number/bedroom_sleep_timer_volume.yaml
+++ b/entities/input_number/bedroom_sleep_timer_volume.yaml
@@ -1,0 +1,7 @@
+bedroom_sleep_timer_volume:
+  name: Volume
+  min: 0
+  max: 100
+  step: 1
+  unit_of_measurement: '%'
+  icon: mdi:volume-high

--- a/entities/input_select/bedroom_sonos_source.yaml
+++ b/entities/input_select/bedroom_sonos_source.yaml
@@ -1,0 +1,14 @@
+bedroom_sonos_source:
+  name: Sonos Source
+  options:
+    - 'Absolute Radio'
+    - 'BBC Radio Manchester'
+    - 'Capital Manchester'
+    - 'Classic FM'
+    - 'Heart'
+    - 'Kisstory'
+    - 'LBC'
+    - 'LBC News'
+    - 'Magic Radio'
+    - 'Smooth Radio UK'
+  icon: mdi:star-box


### PR DESCRIPTION
This automation uses helpers to turn on music/radio to a specified volume and source for a specified duration. It is triggered through an Aqara button.

Related: #264